### PR TITLE
Add mid-flush stale-read tests (#224, #225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Reactive Framework Test Suite
 
-Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **164 test cases**.
+Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **165 test cases**.
 
-> 2029 passed, 265 failed, 166 skipped out of 2460 total runs
+> 2041 passed, 268 failed, 166 skipped out of 2475 total runs
 
 Test cases are collected and adapted from the test suites of all participating frameworks — thanks to every project for their thorough testing work. This suite focuses on **reactive semantics** (propagation, batching, disposal, edge cases), not API completeness. Tests that require an optional capability (e.g. `batch`) are skipped (⬜) for frameworks that don't expose it, rather than marked as failures.
 
@@ -36,21 +36,21 @@ The **Behavioral Differences** section is separate — those tests reflect desig
 
 | Framework              | Pass | Fail | Skip | Total |
 | ---------------------- | ---- | ---- | ---- | ----- |
-| alien-signals          |  164 |    0 |    0 |   164 |
-| @preact/signals-core   |  162 |    2 |    0 |   164 |
-| @reatom/core           |  162 |    2 |    0 |   164 |
-| anod                   |  152 |   12 |    0 |   164 |
-| tansu                  |  148 |    5 |   11 |   164 |
-| @solidjs/signals       |  145 |    8 |   11 |   164 |
-| solid-js               |  140 |   24 |    0 |   164 |
-| mobx                   |  136 |   17 |   11 |   164 |
-| @vue/reactivity        |  133 |   31 |    0 |   164 |
-| signal-polyfill (TC39) |  129 |    8 |   27 |   164 |
-| @angular/core          |  127 |   10 |   27 |   164 |
-| S.js                   |  119 |   45 |    0 |   164 |
-| svelte                 |  118 |   12 |   34 |   164 |
-| @reactively/core       |  102 |   17 |   45 |   164 |
-| pota                   |   92 |   72 |    0 |   164 |
+| alien-signals          |  165 |    0 |    0 |   165 |
+| @preact/signals-core   |  163 |    2 |    0 |   165 |
+| @reatom/core           |  163 |    2 |    0 |   165 |
+| anod                   |  153 |   12 |    0 |   165 |
+| tansu                  |  149 |    5 |   11 |   165 |
+| @solidjs/signals       |  145 |    9 |   11 |   165 |
+| solid-js               |  141 |   24 |    0 |   165 |
+| mobx                   |  137 |   17 |   11 |   165 |
+| @vue/reactivity        |  134 |   31 |    0 |   165 |
+| signal-polyfill (TC39) |  130 |    8 |   27 |   165 |
+| @angular/core          |  128 |   10 |   27 |   165 |
+| S.js                   |  120 |   45 |    0 |   165 |
+| svelte                 |  119 |   12 |   34 |   165 |
+| @reactively/core       |  102 |   18 |   45 |   165 |
+| pota                   |   92 |   73 |    0 |   165 |
 
 ## Results
 
@@ -903,23 +903,23 @@ Legend:
   ═→       inner write (node writes to a signal during evaluation)
 ```
 
-| Framework              | #50,#186 | #51 | #52,#112,... ×11 | #53,#56,... ×5 | #54 | #179 | #57 | #182 | #183,#185 | #213 | #212 |
-| ---------------------- | -------- | --- | ---------------- | -------------- | --- | ---- | --- | ---- | --------- | ---- | ---- |
-| alien-signals          |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| @preact/signals-core   |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| @reactively/core       |        ❌ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ✅ |    ✅ |
-| tansu                  |        ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| signal-polyfill (TC39) |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ❌ |    ❌ |
-| @vue/reactivity        |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
-| mobx                   |        ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| @reatom/core           |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| svelte                 |        ✅ |   ✅ |                ✅ |              ✅ |   ❌ |    ❌ |   ❌ |    ⬜ |         ✅ |    ❌ |    ✅ |
-| solid-js               |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ❌ |    ✅ |    ✅ |
-| @solidjs/signals       |        ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ❌ |    ❌ |
-| S.js                   |        ✅ |   ❌ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ❌ |    ✅ |    ✅ |
-| pota                   |        ❌ |   ❌ |                ✅ |              ❌ |   ❌ |    ❌ |   ✅ |    ❌ |         ❌ |    ❌ |    ❌ |
-| @angular/core          |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ❌ |    ⬜ |         ✅ |    ✅ |    ✅ |
-| anod                   |        ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
+| Framework              | #50,#186,#224 | #51 | #52,#112,... ×11 | #53,#56,... ×5 | #54 | #179 | #57 | #182 | #183,#185 | #213 | #212 |
+| ---------------------- | ------------- | --- | ---------------- | -------------- | --- | ---- | --- | ---- | --------- | ---- | ---- |
+| alien-signals          |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| @preact/signals-core   |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| @reactively/core       |             ❌ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ✅ |    ✅ |
+| tansu                  |             ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| signal-polyfill (TC39) |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ❌ |    ❌ |
+| @vue/reactivity        |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
+| mobx                   |             ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| @reatom/core           |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| svelte                 |             ✅ |   ✅ |                ✅ |              ✅ |   ❌ |    ❌ |   ❌ |    ⬜ |         ✅ |    ❌ |    ✅ |
+| solid-js               |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ❌ |    ✅ |    ✅ |
+| @solidjs/signals       |             ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ❌ |    ❌ |
+| S.js                   |             ✅ |   ❌ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ❌ |    ✅ |    ✅ |
+| pota                   |             ❌ |   ❌ |                ✅ |              ❌ |   ❌ |    ❌ |   ✅ |    ❌ |         ❌ |    ❌ |    ❌ |
+| @angular/core          |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ❌ |    ⬜ |         ✅ |    ✅ |    ✅ |
+| anod                   |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
 
 <details>
 <summary>Tests with failures or skips</summary>
@@ -1083,6 +1083,21 @@ Same pattern as #213 but the initial s starts at 0. The first
 external write triggers the reset. Future writes must still
 propagate through the computed and be caught by the effect.
 
+#### #224 effect sees fresh computed after sibling's mid-flush inner write
+
+```
+ S(a) ─→ E(e1) ═→ S(b) when a===1
+ S(a) ─→ C(c) = a + b
+ C(c) ─→ E(e2)
+```
+
+a.write(1) schedules both e1 and e2. e1's inner write to b
+makes c stale mid-flush. e2 reads c — must observe the fresh
+value (1 + 10 = 11) by the time the flush settles, not the
+stale value (1 + 0 = 1). The assertion only checks the LAST
+observation, tolerating frameworks that fire e2 multiple times
+during the flush.
+
 
 </details>
 
@@ -1102,23 +1117,23 @@ Legend:
   ↔ / ⟳   cyclic dependency
 ```
 
-| Framework              | #61,#152 | #63 | #150 | #151 | #153 | #64,#221,#223 |
-| ---------------------- | -------- | --- | ---- | ---- | ---- | ------------- |
-| alien-signals          |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| @preact/signals-core   |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| @reactively/core       |        ✅ |   ✅ |    ✅ |    ⬜ |    ✅ |             ❌ |
-| tansu                  |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| signal-polyfill (TC39) |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| @vue/reactivity        |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| mobx                   |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| @reatom/core           |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| svelte                 |        ✅ |   ✅ |    ✅ |    ⬜ |    ❌ |             ✅ |
-| solid-js               |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| @solidjs/signals       |        ✅ |   ✅ |    ❌ |    ✅ |    ✅ |             ✅ |
-| S.js                   |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| pota                   |        ✅ |   ❌ |    ✅ |    ✅ |    ✅ |             ✅ |
-| @angular/core          |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
-| anod                   |        ✅ |   ✅ |    ✅ |    ✅ |    ✅ |             ✅ |
+| Framework              | #61 | #63 | #150,#152 | #151 | #153 | #64,#221,#223 |
+| ---------------------- | --- | --- | --------- | ---- | ---- | ------------- |
+| alien-signals          |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| @preact/signals-core   |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| @reactively/core       |   ✅ |   ✅ |         ✅ |    ⬜ |    ✅ |             ❌ |
+| tansu                  |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| signal-polyfill (TC39) |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| @vue/reactivity        |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| mobx                   |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| @reatom/core           |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| svelte                 |   ✅ |   ✅ |         ✅ |    ⬜ |    ❌ |             ✅ |
+| solid-js               |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| @solidjs/signals       |   ✅ |   ✅ |         ❌ |    ✅ |    ✅ |             ✅ |
+| S.js                   |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| pota                   |   ✅ |   ❌ |         ✅ |    ✅ |    ✅ |             ✅ |
+| @angular/core          |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
+| anod                   |   ✅ |   ✅ |         ✅ |    ✅ |    ✅ |             ✅ |
 
 <details>
 <summary>Tests with failures or skips</summary>
@@ -1159,6 +1174,17 @@ Framework should throw or handle the late-onset cycle.
 A computed reads itself inside an untracked scope.
 Even without a tracked dependency edge, re-entering the
 same computation is still a cycle.
+
+#### #152 conditional computed becomes recursive on flag change
+
+```
+ S(flag)
+    |
+  C(c) ⟳  (when flag=true)
+```
+
+When flag=false, c returns 0 (no cycle). Setting flag=true
+makes c read itself, creating a conditional self-cycle.
 
 #### #153 computed self-dep recovery after catching cycle error
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Reactive Framework Test Suite
 
-Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **165 test cases**.
+Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **166 test cases**.
 
-> 2041 passed, 268 failed, 166 skipped out of 2475 total runs
+> 2054 passed, 270 failed, 166 skipped out of 2490 total runs
 
 Test cases are collected and adapted from the test suites of all participating frameworks — thanks to every project for their thorough testing work. This suite focuses on **reactive semantics** (propagation, batching, disposal, edge cases), not API completeness. Tests that require an optional capability (e.g. `batch`) are skipped (⬜) for frameworks that don't expose it, rather than marked as failures.
 
@@ -36,21 +36,21 @@ The **Behavioral Differences** section is separate — those tests reflect desig
 
 | Framework              | Pass | Fail | Skip | Total |
 | ---------------------- | ---- | ---- | ---- | ----- |
-| alien-signals          |  165 |    0 |    0 |   165 |
-| @preact/signals-core   |  163 |    2 |    0 |   165 |
-| @reatom/core           |  163 |    2 |    0 |   165 |
-| anod                   |  153 |   12 |    0 |   165 |
-| tansu                  |  149 |    5 |   11 |   165 |
-| @solidjs/signals       |  145 |    9 |   11 |   165 |
-| solid-js               |  141 |   24 |    0 |   165 |
-| mobx                   |  137 |   17 |   11 |   165 |
-| @vue/reactivity        |  134 |   31 |    0 |   165 |
-| signal-polyfill (TC39) |  130 |    8 |   27 |   165 |
-| @angular/core          |  128 |   10 |   27 |   165 |
-| S.js                   |  120 |   45 |    0 |   165 |
-| svelte                 |  119 |   12 |   34 |   165 |
-| @reactively/core       |  102 |   18 |   45 |   165 |
-| pota                   |   92 |   73 |    0 |   165 |
+| alien-signals          |  166 |    0 |    0 |   166 |
+| @preact/signals-core   |  164 |    2 |    0 |   166 |
+| @reatom/core           |  164 |    2 |    0 |   166 |
+| anod                   |  154 |   12 |    0 |   166 |
+| tansu                  |  150 |    5 |   11 |   166 |
+| @solidjs/signals       |  146 |    9 |   11 |   166 |
+| solid-js               |  142 |   24 |    0 |   166 |
+| mobx                   |  138 |   17 |   11 |   166 |
+| @vue/reactivity        |  135 |   31 |    0 |   166 |
+| signal-polyfill (TC39) |  131 |    8 |   27 |   166 |
+| @angular/core          |  129 |   10 |   27 |   166 |
+| S.js                   |  121 |   45 |    0 |   166 |
+| svelte                 |  120 |   12 |   34 |   166 |
+| @reactively/core       |  102 |   19 |   45 |   166 |
+| pota                   |   92 |   74 |    0 |   166 |
 
 ## Results
 
@@ -903,23 +903,23 @@ Legend:
   ═→       inner write (node writes to a signal during evaluation)
 ```
 
-| Framework              | #50,#186,#224 | #51 | #52,#112,... ×11 | #53,#56,... ×5 | #54 | #179 | #57 | #182 | #183,#185 | #213 | #212 |
-| ---------------------- | ------------- | --- | ---------------- | -------------- | --- | ---- | --- | ---- | --------- | ---- | ---- |
-| alien-signals          |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| @preact/signals-core   |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| @reactively/core       |             ❌ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ✅ |    ✅ |
-| tansu                  |             ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| signal-polyfill (TC39) |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ❌ |    ❌ |
-| @vue/reactivity        |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
-| mobx                   |             ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| @reatom/core           |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
-| svelte                 |             ✅ |   ✅ |                ✅ |              ✅ |   ❌ |    ❌ |   ❌ |    ⬜ |         ✅ |    ❌ |    ✅ |
-| solid-js               |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ❌ |    ✅ |    ✅ |
-| @solidjs/signals       |             ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ❌ |    ❌ |
-| S.js                   |             ✅ |   ❌ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ❌ |    ✅ |    ✅ |
-| pota                   |             ❌ |   ❌ |                ✅ |              ❌ |   ❌ |    ❌ |   ✅ |    ❌ |         ❌ |    ❌ |    ❌ |
-| @angular/core          |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ❌ |    ⬜ |         ✅ |    ✅ |    ✅ |
-| anod                   |             ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
+| Framework              | #50,#186,... ×4 | #51 | #52,#112,... ×11 | #53,#56,... ×5 | #54 | #179 | #57 | #182 | #183,#185 | #213 | #212 |
+| ---------------------- | --------------- | --- | ---------------- | -------------- | --- | ---- | --- | ---- | --------- | ---- | ---- |
+| alien-signals          |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| @preact/signals-core   |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| @reactively/core       |               ❌ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ✅ |    ✅ |
+| tansu                  |               ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| signal-polyfill (TC39) |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ⬜ |         ✅ |    ❌ |    ❌ |
+| @vue/reactivity        |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
+| mobx                   |               ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ✅ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| @reatom/core           |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ✅ |    ✅ |
+| svelte                 |               ✅ |   ✅ |                ✅ |              ✅ |   ❌ |    ❌ |   ❌ |    ⬜ |         ✅ |    ❌ |    ✅ |
+| solid-js               |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ❌ |    ✅ |    ✅ |
+| @solidjs/signals       |               ✅ |   ⬜ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ✅ |         ✅ |    ❌ |    ❌ |
+| S.js                   |               ✅ |   ❌ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ❌ |    ✅ |    ✅ |
+| pota                   |               ❌ |   ❌ |                ✅ |              ❌ |   ❌ |    ❌ |   ✅ |    ❌ |         ❌ |    ❌ |    ❌ |
+| @angular/core          |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ❌ |    ⬜ |         ✅ |    ✅ |    ✅ |
+| anod                   |               ✅ |   ✅ |                ✅ |              ✅ |   ✅ |    ❌ |   ✅ |    ❌ |         ✅ |    ✅ |    ✅ |
 
 <details>
 <summary>Tests with failures or skips</summary>
@@ -1097,6 +1097,21 @@ value (1 + 10 = 11) by the time the flush settles, not the
 stale value (1 + 0 = 1). The assertion only checks the LAST
 observation, tolerating frameworks that fire e2 multiple times
 during the flush.
+
+#### #225 mid-flush fan-in: e3 sees both sibling effects' inner writes
+
+```
+ S(a) ─→ E(e1) ═→ S(b1) when a===1
+ S(a) ─→ E(e2) ═→ S(b2) when a===1
+ S(b1), S(b2) ─→ C(c) = b1 + b2
+ C(c) ─→ E(e3)
+```
+
+Two effects each inner-write a different signal during the
+same flush. Both feed into a single computed read by a third
+effect. The LAST value e3 observes must be 30 (b1=10 + b2=20),
+not a partial state where only one inner write is reflected.
+Like #224, only checks the final settled observation.
 
 
 </details>

--- a/src/innerWrite.ts
+++ b/src/innerWrite.ts
@@ -928,4 +928,46 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
     a.write(1);
     expect(observed[observed.length - 1]).toBe(11);
   },
+
+  /**
+   *  S(a) ─→ E(e1) ═→ S(b1) when a===1
+   *  S(a) ─→ E(e2) ═→ S(b2) when a===1
+   *  S(b1), S(b2) ─→ C(c) = b1 + b2
+   *  C(c) ─→ E(e3)
+   *
+   * Two effects each inner-write a different signal during the
+   * same flush. Both feed into a single computed read by a third
+   * effect. The LAST value e3 observes must be 30 (b1=10 + b2=20),
+   * not a partial state where only one inner write is reflected.
+   * Like #224, only checks the final settled observation.
+   */
+  "#225 mid-flush fan-in: e3 sees both sibling effects' inner writes"(
+    fw: ReactiveFramework
+  ) {
+    const a = fw.signal(0);
+    const b1 = fw.signal(0);
+    const b2 = fw.signal(0);
+    const c = fw.computed(() => b1.read() + b2.read());
+
+    const observed: number[] = [];
+
+    fw.effect(() => {
+      if (a.read() === 1) {
+        b1.write(10);
+      }
+    });
+    fw.effect(() => {
+      if (a.read() === 1) {
+        b2.write(20);
+      }
+    });
+    fw.effect(() => {
+      observed.push(c.read());
+    });
+
+    expect(observed).toEqual([0]);
+
+    a.write(1);
+    expect(observed[observed.length - 1]).toBe(30);
+  },
 };

--- a/src/innerWrite.ts
+++ b/src/innerWrite.ts
@@ -892,4 +892,40 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
     s.write(3);
     expect(s.read()).toBe(0);
   },
+
+  /**
+   *  S(a) ─→ E(e1) ═→ S(b) when a===1
+   *  S(a) ─→ C(c) = a + b
+   *  C(c) ─→ E(e2)
+   *
+   * a.write(1) schedules both e1 and e2. e1's inner write to b
+   * makes c stale mid-flush. e2 reads c — must observe the fresh
+   * value (1 + 10 = 11) by the time the flush settles, not the
+   * stale value (1 + 0 = 1). The assertion only checks the LAST
+   * observation, tolerating frameworks that fire e2 multiple times
+   * during the flush.
+   */
+  "#224 effect sees fresh computed after sibling's mid-flush inner write"(
+    fw: ReactiveFramework
+  ) {
+    const a = fw.signal(0);
+    const b = fw.signal(0);
+    const c = fw.computed(() => a.read() + b.read());
+
+    const observed: number[] = [];
+
+    fw.effect(() => {
+      if (a.read() === 1) {
+        b.write(10);
+      }
+    });
+    fw.effect(() => {
+      observed.push(c.read());
+    });
+
+    expect(observed).toEqual([0]);
+
+    a.write(1);
+    expect(observed[observed.length - 1]).toBe(11);
+  },
 };


### PR DESCRIPTION
## Summary

Adds two Inner Write tests for the "mid-flush stale read" scenario — a property no other test covered: when one effect inner-writes during a flush, does another effect observing a downstream computed see the fresh post-write value?

Both tests use a robust `observed[last]` assertion, so frameworks that fire the observing effect once **or** multiple times during the flush both pass as long as the final state is correct. This avoids depending on scheduler-specific ordering.

### `#224 effect sees fresh computed after sibling's mid-flush inner write`
```
S(a) ─→ E(e1) ═→ S(b) when a===1
S(a) ─→ C(c) = a + b
C(c) ─→ E(e2)
```
`a.write(1)` schedules both `e1` and `e2`. `e1`'s inner write to `b` makes `c` stale. `e2` reads `c` — last value must be `1 + 10 = 11`, not the stale `1 + 0 = 1`.

### `#225 mid-flush fan-in: e3 sees both sibling effects' inner writes`
```
S(a) ─→ E(e1) ═→ S(b1) when a===1
S(a) ─→ E(e2) ═→ S(b2) when a===1
S(b1), S(b2) ─→ C(c) = b1 + b2
C(c) ─→ E(e3)
```
Two parallel inner writes feed into one computed. `e3`'s last observation must be `30` (both writes coalesced), not a partial state where only one write propagated.

## Distinct from existing tests

- `#54`: effect's own settling — single effect.
- `#133` / `#134`: cross-effect inner writes via direct signal reads — no computed in between.
- `#186`: computed side-channel write inside the computed itself — not effect inner write.

`#224` and `#225` specifically exercise whether a computed correctly refreshes mid-flush when its dependency is mutated by another effect's body. `#225` extends to multiple parallel inner writes coalescing into one computed.

## Matrix differences surfaced

| Framework | `#224` | `#225` |
|---|---|---|
| alien-signals | ✅ | ✅ |
| @reactively/core | ❌ | ❌ |
| pota | ❌ | ❌ |
| all others | ✅ | ✅ |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 2730 passed (15 frameworks × (166 non-behavioral + 16 behavioral))
- [x] README regenerated