### PR TITLE
Clean up tautological cycle tests + harden #153

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Reactive Framework Test Suite
 
-Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **166 test cases**.
+Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **163 test cases**.
 
-> 2056 passed, 268 failed, 166 skipped out of 2490 total runs
+> 2012 passed, 269 failed, 164 skipped out of 2445 total runs
 
 Test cases are collected and adapted from the test suites of all participating frameworks — thanks to every project for their thorough testing work. This suite focuses on **reactive semantics** (propagation, batching, disposal, edge cases), not API completeness. Tests that require an optional capability (e.g. `batch`) are skipped (⬜) for frameworks that don't expose it, rather than marked as failures.
 
@@ -36,21 +36,21 @@ The **Behavioral Differences** section is separate — those tests reflect desig
 
 | Framework              | Pass | Fail | Skip | Total |
 | ---------------------- | ---- | ---- | ---- | ----- |
-| alien-signals          |  166 |    0 |    0 |   166 |
-| @preact/signals-core   |  164 |    2 |    0 |   166 |
-| @reatom/core           |  164 |    2 |    0 |   166 |
-| anod                   |  154 |   12 |    0 |   166 |
-| tansu                  |  150 |    5 |   11 |   166 |
-| @solidjs/signals       |  148 |    7 |   11 |   166 |
-| solid-js               |  142 |   24 |    0 |   166 |
-| mobx                   |  138 |   17 |   11 |   166 |
-| @vue/reactivity        |  135 |   31 |    0 |   166 |
-| signal-polyfill (TC39) |  131 |    8 |   27 |   166 |
-| @angular/core          |  129 |   10 |   27 |   166 |
-| S.js                   |  121 |   45 |    0 |   166 |
-| svelte                 |  120 |   12 |   34 |   166 |
-| @reactively/core       |  102 |   19 |   45 |   166 |
-| pota                   |   92 |   74 |    0 |   166 |
+| alien-signals          |  163 |    0 |    0 |   163 |
+| @preact/signals-core   |  161 |    2 |    0 |   163 |
+| @reatom/core           |  160 |    3 |    0 |   163 |
+| anod                   |  151 |   12 |    0 |   163 |
+| tansu                  |  147 |    5 |   11 |   163 |
+| @solidjs/signals       |  145 |    7 |   11 |   163 |
+| solid-js               |  139 |   24 |    0 |   163 |
+| mobx                   |  135 |   17 |   11 |   163 |
+| @vue/reactivity        |  132 |   31 |    0 |   163 |
+| signal-polyfill (TC39) |  128 |    8 |   27 |   163 |
+| @angular/core          |  126 |   10 |   27 |   163 |
+| svelte                 |  118 |   12 |   33 |   163 |
+| S.js                   |  118 |   45 |    0 |   163 |
+| @reactively/core       |  100 |   19 |   44 |   163 |
+| pota                   |   89 |   74 |    0 |   163 |
 
 ## Results
 
@@ -1132,23 +1132,23 @@ Legend:
   ↔ / ⟳   cyclic dependency
 ```
 
-| Framework              | #61,#150,#152 | #63 | #151 | #153 | #64,#221,#223 |
-| ---------------------- | ------------- | --- | ---- | ---- | ------------- |
-| alien-signals          |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| @preact/signals-core   |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| @reactively/core       |             ✅ |   ✅ |    ⬜ |    ✅ |             ❌ |
-| tansu                  |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| signal-polyfill (TC39) |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| @vue/reactivity        |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| mobx                   |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| @reatom/core           |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| svelte                 |             ✅ |   ✅ |    ⬜ |    ❌ |             ✅ |
-| solid-js               |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| @solidjs/signals       |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| S.js                   |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| pota                   |             ✅ |   ❌ |    ✅ |    ✅ |             ✅ |
-| @angular/core          |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
-| anod                   |             ✅ |   ✅ |    ✅ |    ✅ |             ✅ |
+| Framework              | #61 | #63 | #153 | #64,#221,#223 |
+| ---------------------- | --- | --- | ---- | ------------- |
+| alien-signals          |   ✅ |   ✅ |    ✅ |             ✅ |
+| @preact/signals-core   |   ✅ |   ✅ |    ✅ |             ✅ |
+| @reactively/core       |   ✅ |   ✅ |    ✅ |             ❌ |
+| tansu                  |   ✅ |   ✅ |    ✅ |             ✅ |
+| signal-polyfill (TC39) |   ✅ |   ✅ |    ✅ |             ✅ |
+| @vue/reactivity        |   ✅ |   ✅ |    ✅ |             ✅ |
+| mobx                   |   ✅ |   ✅ |    ✅ |             ✅ |
+| @reatom/core           |   ✅ |   ✅ |    ❌ |             ✅ |
+| svelte                 |   ✅ |   ✅ |    ❌ |             ✅ |
+| solid-js               |   ✅ |   ✅ |    ✅ |             ✅ |
+| @solidjs/signals       |   ✅ |   ✅ |    ✅ |             ✅ |
+| S.js                   |   ✅ |   ✅ |    ✅ |             ✅ |
+| pota                   |   ✅ |   ❌ |    ✅ |             ✅ |
+| @angular/core          |   ✅ |   ✅ |    ✅ |             ✅ |
+| anod                   |   ✅ |   ✅ |    ✅ |             ✅ |
 
 <details>
 <summary>Tests with failures or skips</summary>
@@ -1166,16 +1166,6 @@ Legend:
 Effect is safe when cond=false. Setting cond=true creates a
 dynamic read-write cycle on a. Framework must detect it.
 
-#### #151 self-reference via untracked: cycle still detected
-
-```
- C(c) ──untracked──→ C(c)  ⟳
-```
-
-A computed reads itself inside an untracked scope.
-Even without a tracked dependency edge, re-entering the
-same computation is still a cycle.
-
 #### #153 computed self-dep recovery after catching cycle error
 
 ```
@@ -1185,7 +1175,7 @@ same computation is still a cycle.
 ```
 
 When a=0, c tries to read itself (cycle) and catches the error.
-After setting a=1, c should recover and return a's value.
+After setting a=1, c must recover and return a's value.
 
 #### #64 max iteration limit reached
 

--- a/src/cycleDetection.ts
+++ b/src/cycleDetection.ts
@@ -79,113 +79,12 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
   },
 
   /**
-   *  S(cond)
-   *     |
-   *   C(b) ──→ C(a)
-   *     ↑        |
-   *     └────────┘  ⟳  (when cond=true)
-   *
-   * When cond=false, b returns 0 and no cycle exists.
-   * Setting cond=true makes b read a, forming a↔b cycle.
-   * Framework should throw or handle the late-onset cycle.
-   */
-  "#150 dynamic cycle: computed pair becomes cyclic on condition change"(
-    fw: ReactiveFramework
-  ) {
-    const cond = fw.signal(false);
-    let threw = false;
-
-    try {
-      let aRef: any;
-      const b = fw.computed(() => {
-        if (cond.read()) return aRef?.read();
-        return 0;
-      });
-      const a = fw.computed(() => b.read());
-      aRef = a;
-
-      expect(a.read()).toBe(0);
-
-      cond.write(true);
-      a.read();
-    } catch {
-      threw = true;
-    }
-
-    expect(true).toBe(true);
-  },
-
-  /**
-   *  C(c) ──untracked──→ C(c)  ⟳
-   *
-   * A computed reads itself inside an untracked scope.
-   * Even without a tracked dependency edge, re-entering the
-   * same computation is still a cycle.
-   */
-  "#151 self-reference via untracked: cycle still detected"(
-    fw: ReactiveFramework
-  ) {
-    if (!fw.untracked) throw new SkipTest("no untracked");
-    let threw = false;
-    try {
-      const c = fw.computed((): number => {
-        return fw.untracked!(() => {
-          try {
-            return (c as any).read() + 1;
-          } catch {
-            return 0;
-          }
-        });
-      });
-      c.read();
-    } catch {
-      threw = true;
-    }
-    expect(true).toBe(true);
-  },
-
-  /**
-   *  S(flag)
-   *     |
-   *   C(c) ⟳  (when flag=true)
-   *
-   * When flag=false, c returns 0 (no cycle). Setting flag=true
-   * makes c read itself, creating a conditional self-cycle.
-   */
-  "#152 conditional computed becomes recursive on flag change"(
-    fw: ReactiveFramework
-  ) {
-    const flag = fw.signal(false);
-    let threw = false;
-
-    try {
-      const c = fw.computed((): number => {
-        if (flag.read()) {
-          try {
-            return (c as any).read() + 1;
-          } catch {
-            return 99;
-          }
-        }
-        return 0;
-      });
-
-      expect(c.read()).toBe(0);
-      flag.write(true);
-      c.read();
-    } catch {
-      threw = true;
-    }
-    expect(true).toBe(true);
-  },
-
-  /**
    *  S(a) → C(c) ⟳  (when a=0, c reads itself)
    *           |
    *         a.write(1) → C(c) reads a normally
    *
    * When a=0, c tries to read itself (cycle) and catches the error.
-   * After setting a=1, c should recover and return a's value.
+   * After setting a=1, c must recover and return a's value.
    */
   "#153 computed self-dep recovery after catching cycle error"(
     fw: ReactiveFramework
@@ -208,9 +107,7 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
     } catch {}
 
     a.write(1);
-    try {
-      expect(c.read()).toBe(1);
-    } catch {}
+    expect(c.read()).toBe(1);
   },
 
   /**


### PR DESCRIPTION
## Summary

Cleans up four cycle-detection tests that share the same problem we already addressed for `#58`/`#59`/`#60`: their visible assertion is `expect(true).toBe(true)` and the only real check is "the test doesn't time out".

These also caused **flaky CI behavior**: @solidjs/signals throws cycle errors asynchronously, and depending on platform-specific microtask timing, the throw either lands inside the test's try/catch (test passes) or escapes after it (test fails). macOS local and Linux CI gave different results for these tests.

## Changes

### Removed (tautological)

| Test | Property already covered by |
|------|------------------------------|
| `#150 dynamic cycle: computed pair becomes cyclic on condition change` | `#63` (dynamic cycle creation) |
| `#151 self-reference via untracked: cycle still detected` | `#61` / `#64` / `#221` / `#223` (cycle bounding) |
| `#152 conditional computed becomes recursive on flag change` | `#63` |

### Hardened

`#153 computed self-dep recovery after catching cycle error` was also effectively tautological — the recovery assertion was wrapped in `try/catch` that silently swallowed failures. Now asserts `expect(c.read()).toBe(1)` directly. `@reatom/core` and `svelte` fail this where they previously passed.

## Resulting Cycle section

| Test | Property | Real assertion? |
|------|----------|-----------------|
| `#61` | indirect cycle via effects | ✅ `iterations <= 200` |
| `#63` | dynamic cycle creation | ✅ `iterations <= 200` |
| `#64` | max iteration (2-effect ping-pong) | ✅ `iterations <= 300` |
| `#153` | cycle recovery | ✅ `c.read() === 1` (hardened) |
| `#221` | 3-effect cycle | ✅ `iterations <= 300` |
| `#223` | cycle through computed | ✅ `iterations <= 300` |

Plus `#62` in Behavioral Differences (returns descriptive string).

166 → 163 tests.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 2685 passed (15 frameworks × (163 non-behavioral + 16 behavioral))
- [x] README regenerated