### PR TITLE
Add setExpect API for consumer's expect implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2084,7 +2084,12 @@ const myFramework: ReactiveFramework = {
 Wire it up with your test runner (vitest, jest, mocha, etc.):
 
 ```ts
-import { testSuite, SkipTest } from "reactive-framework-test-suite";
+import { testSuite, SkipTest, setExpect } from "reactive-framework-test-suite";
+import { expect } from "vitest";
+
+// Optional: swap the built-in expect for your runner's
+// for richer error messages and tighter integration.
+setExpect(expect);
 
 for (const { section, cases } of testSuite) {
   describe(section, () => {

--- a/scripts/update-readme.mjs
+++ b/scripts/update-readme.mjs
@@ -515,7 +515,12 @@ const myFramework: ReactiveFramework = {
 Wire it up with your test runner (vitest, jest, mocha, etc.):
 
 \`\`\`ts
-import { testSuite, SkipTest } from "reactive-framework-test-suite";
+import { testSuite, SkipTest, setExpect } from "reactive-framework-test-suite";
+import { expect } from "vitest";
+
+// Optional: swap the built-in expect for your runner's
+// for richer error messages and tighter integration.
+setExpect(expect);
 
 for (const { section, cases } of testSuite) {
   describe(section, () => {

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,4 +1,6 @@
-export function expect(actual: unknown) {
+type ExpectFn = (actual: unknown) => any;
+
+const defaultExpect: ExpectFn = (actual) => {
   return {
     toBe(expected: unknown) {
       if (!Object.is(actual, expected)) {
@@ -86,4 +88,19 @@ export function expect(actual: unknown) {
       },
     },
   };
+};
+
+let activeExpect: ExpectFn = defaultExpect;
+
+/**
+ * Replace the built-in expect with one from your test runner
+ * (e.g. vitest's `expect`) for richer error messages and tighter
+ * integration. Pass nothing to restore the built-in implementation.
+ */
+export function setExpect(fn?: ExpectFn): void {
+  activeExpect = fn ?? defaultExpect;
+}
+
+export function expect(actual: unknown) {
+  return activeExpect(actual);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export type { ReactiveFramework, Signal, Computed } from "./framework.js";
 export { SkipTest, detectCapabilities, hasEffectCleanup, hasComputedThrows } from "./framework.js";
-export { expect } from "./assert.js";
+export { expect, setExpect } from "./assert.js";
 
 import type { ReactiveFramework } from "./framework.js";
 


### PR DESCRIPTION
## Summary

The built-in expect (`src/assert.ts`) is a minimal subset that throws plain `Error`s. Consumers using vitest, jest, etc. couldn't swap in their runner's expect without forking the test suite — losing colored diffs, snapshot integration, and richer stack traces.

This PR adds a small `setExpect` function so consumers can plug in any expect-shaped implementation:

```ts
import { setExpect } from "reactive-framework-test-suite";
import { expect } from "vitest";

setExpect(expect);
```

Pass nothing (`setExpect()`) to restore the built-in. Existing consumers that don't call `setExpect` see **no behavior change**.

## Implementation

`src/assert.ts` keeps the existing matcher set as the default. A module-level `activeExpect` variable holds the current impl; the exported `expect` delegates to it. `setExpect(fn?)` swaps it.

The `ExpectFn` signature is loose (`(actual: unknown) => any`) — vitest's `expect` is structurally compatible. Test files unchanged.

## README

Usage example in `scripts/update-readme.mjs` updated to show the new API.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 2685 passed (no regression)
- [x] README regenerated