### PR TITLE
Add coverage for parent-child link integrity (#226-#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Reactive Framework Test Suite
 
-Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **163 test cases**.
+Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **164 test cases**.
 
-> 2036 passed, 245 failed, 164 skipped out of 2445 total runs
+> 2048 passed, 248 failed, 164 skipped out of 2460 total runs
 
 Test cases are collected and adapted from the test suites of all participating frameworks — thanks to every project for their thorough testing work. This suite focuses on **reactive semantics** (propagation, batching, disposal, edge cases), not API completeness. Tests that require an optional capability (e.g. `batch`) are skipped (⬜) for frameworks that don't expose it, rather than marked as failures.
 
@@ -36,21 +36,21 @@ The **Behavioral Differences** section is separate — those tests reflect desig
 
 | Framework              | Pass | Fail | Skip | Total |
 | ---------------------- | ---- | ---- | ---- | ----- |
-| alien-signals          |  163 |    0 |    0 |   163 |
-| @preact/signals-core   |  161 |    2 |    0 |   163 |
-| @reatom/core           |  160 |    3 |    0 |   163 |
-| @vue/reactivity        |  156 |    7 |    0 |   163 |
-| anod                   |  151 |   12 |    0 |   163 |
-| tansu                  |  147 |    5 |   11 |   163 |
-| @solidjs/signals       |  145 |    7 |   11 |   163 |
-| solid-js               |  139 |   24 |    0 |   163 |
-| mobx                   |  135 |   17 |   11 |   163 |
-| signal-polyfill (TC39) |  128 |    8 |   27 |   163 |
-| @angular/core          |  126 |   10 |   27 |   163 |
-| svelte                 |  118 |   12 |   33 |   163 |
-| S.js                   |  118 |   45 |    0 |   163 |
-| @reactively/core       |  100 |   19 |   44 |   163 |
-| pota                   |   89 |   74 |    0 |   163 |
+| alien-signals          |  163 |    1 |    0 |   164 |
+| @preact/signals-core   |  162 |    2 |    0 |   164 |
+| @reatom/core           |  161 |    3 |    0 |   164 |
+| @vue/reactivity        |  157 |    7 |    0 |   164 |
+| anod                   |  152 |   12 |    0 |   164 |
+| tansu                  |  148 |    5 |   11 |   164 |
+| @solidjs/signals       |  146 |    7 |   11 |   164 |
+| solid-js               |  140 |   24 |    0 |   164 |
+| mobx                   |  136 |   17 |   11 |   164 |
+| signal-polyfill (TC39) |  129 |    8 |   27 |   164 |
+| @angular/core          |  127 |   10 |   27 |   164 |
+| svelte                 |  119 |   12 |   33 |   164 |
+| S.js                   |  119 |   45 |    0 |   164 |
+| @reactively/core       |  100 |   20 |   44 |   164 |
+| pota                   |   89 |   75 |    0 |   164 |
 
 ## Results
 
@@ -760,23 +760,23 @@ Legend:
   ✕        disposed / cleaned up
 ```
 
-| Framework              | #43,#48 | #45 | #46 | #47 | #163 | #164 | #170 | #209 | #210 |
-| ---------------------- | ------- | --- | --- | --- | ---- | ---- | ---- | ---- | ---- |
-| alien-signals          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
-| @preact/signals-core   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |
-| @reactively/core       |       ❌ |   ⬜ |   ✅ |   ✅ |    ❌ |    ❌ |    ❌ |    ❌ |    ❌ |
-| tansu                  |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |
-| signal-polyfill (TC39) |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |
-| @vue/reactivity        |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |
-| mobx                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |
-| @reatom/core           |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
-| svelte                 |       ✅ |   ⬜ |   ✅ |   ❌ |    ❌ |    ✅ |    ✅ |    ❌ |    ❌ |
-| solid-js               |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |
-| @solidjs/signals       |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
-| S.js                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ❌ |
-| pota                   |       ✅ |   ✅ |   ❌ |   ✅ |    ❌ |    ❌ |    ✅ |    ✅ |    ❌ |
-| @angular/core          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |
-| anod                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
+| Framework              | #43,#48 | #45 | #46 | #47 | #163 | #164 | #170 | #209 | #210 | #226 |
+| ---------------------- | ------- | --- | --- | --- | ---- | ---- | ---- | ---- | ---- | ---- |
+| alien-signals          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ❌ |
+| @preact/signals-core   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| @reactively/core       |       ❌ |   ⬜ |   ✅ |   ✅ |    ❌ |    ❌ |    ❌ |    ❌ |    ❌ |    ❌ |
+| tansu                  |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| signal-polyfill (TC39) |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| @vue/reactivity        |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| mobx                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| @reatom/core           |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
+| svelte                 |       ✅ |   ⬜ |   ✅ |   ❌ |    ❌ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| solid-js               |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| @solidjs/signals       |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
+| S.js                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ❌ |    ✅ |
+| pota                   |       ✅ |   ✅ |   ❌ |   ✅ |    ❌ |    ❌ |    ✅ |    ✅ |    ❌ |    ❌ |
+| @angular/core          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
+| anod                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
 
 <details>
 <summary>Tests with failures or skips</summary>
@@ -881,6 +881,21 @@ the new inner effects should respond to b and c changes.
 
 Inner effect captures a closure variable from the outer effect.
 The observed value must reflect the outer's current execution.
+
+#### #226 outer keeps responding to own deps after inner re-runs
+
+```
+ S(a) ─→ E_outer{ E_inner ─→ S(b) }
+```
+
+Outer reads a and creates an inner effect that reads b.
+After b changes (which re-runs only the inner), the outer
+must still respond to subsequent writes to its own dep a.
+
+Regression observed in alien-signals 3.2.0 (works in 3.1.2):
+after the inner re-runs once on its own, the outer's link
+to a is dropped and a.write no longer triggers it.
+See https://github.com/stackblitz/alien-signals/issues/115
 
 
 </details>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Reactive Framework Test Suite
 
-Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **164 test cases**.
+Cross-library test suite for comparing reactive signal behavior across **15 frameworks** with **166 test cases**.
 
-> 2048 passed, 248 failed, 164 skipped out of 2460 total runs
+> 2072 passed, 254 failed, 164 skipped out of 2490 total runs
 
 Test cases are collected and adapted from the test suites of all participating frameworks — thanks to every project for their thorough testing work. This suite focuses on **reactive semantics** (propagation, batching, disposal, edge cases), not API completeness. Tests that require an optional capability (e.g. `batch`) are skipped (⬜) for frameworks that don't expose it, rather than marked as failures.
 
@@ -36,21 +36,21 @@ The **Behavioral Differences** section is separate — those tests reflect desig
 
 | Framework              | Pass | Fail | Skip | Total |
 | ---------------------- | ---- | ---- | ---- | ----- |
-| alien-signals          |  163 |    1 |    0 |   164 |
-| @preact/signals-core   |  162 |    2 |    0 |   164 |
-| @reatom/core           |  161 |    3 |    0 |   164 |
-| @vue/reactivity        |  157 |    7 |    0 |   164 |
-| anod                   |  152 |   12 |    0 |   164 |
-| tansu                  |  148 |    5 |   11 |   164 |
-| @solidjs/signals       |  146 |    7 |   11 |   164 |
-| solid-js               |  140 |   24 |    0 |   164 |
-| mobx                   |  136 |   17 |   11 |   164 |
-| signal-polyfill (TC39) |  129 |    8 |   27 |   164 |
-| @angular/core          |  127 |   10 |   27 |   164 |
-| svelte                 |  119 |   12 |   33 |   164 |
-| S.js                   |  119 |   45 |    0 |   164 |
-| @reactively/core       |  100 |   20 |   44 |   164 |
-| pota                   |   89 |   75 |    0 |   164 |
+| @preact/signals-core   |  164 |    2 |    0 |   166 |
+| alien-signals          |  163 |    3 |    0 |   166 |
+| @reatom/core           |  163 |    3 |    0 |   166 |
+| @vue/reactivity        |  159 |    7 |    0 |   166 |
+| anod                   |  154 |   12 |    0 |   166 |
+| tansu                  |  150 |    5 |   11 |   166 |
+| @solidjs/signals       |  148 |    7 |   11 |   166 |
+| solid-js               |  142 |   24 |    0 |   166 |
+| mobx                   |  138 |   17 |   11 |   166 |
+| signal-polyfill (TC39) |  131 |    8 |   27 |   166 |
+| @angular/core          |  129 |   10 |   27 |   166 |
+| svelte                 |  121 |   12 |   33 |   166 |
+| S.js                   |  121 |   45 |    0 |   166 |
+| @reactively/core       |  100 |   22 |   44 |   166 |
+| pota                   |   89 |   77 |    0 |   166 |
 
 ## Results
 
@@ -760,23 +760,23 @@ Legend:
   ✕        disposed / cleaned up
 ```
 
-| Framework              | #43,#48 | #45 | #46 | #47 | #163 | #164 | #170 | #209 | #210 | #226 |
-| ---------------------- | ------- | --- | --- | --- | ---- | ---- | ---- | ---- | ---- | ---- |
-| alien-signals          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ❌ |
-| @preact/signals-core   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| @reactively/core       |       ❌ |   ⬜ |   ✅ |   ✅ |    ❌ |    ❌ |    ❌ |    ❌ |    ❌ |    ❌ |
-| tansu                  |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| signal-polyfill (TC39) |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| @vue/reactivity        |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| mobx                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| @reatom/core           |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
-| svelte                 |       ✅ |   ⬜ |   ✅ |   ❌ |    ❌ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| solid-js               |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| @solidjs/signals       |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
-| S.js                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ❌ |    ✅ |
-| pota                   |       ✅ |   ✅ |   ❌ |   ✅ |    ❌ |    ❌ |    ✅ |    ✅ |    ❌ |    ❌ |
-| @angular/core          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ✅ |
-| anod                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |
+| Framework              | #43,#48 | #45 | #46 | #47 | #163 | #164 | #170 | #209 | #210 | #226..#228 |
+| ---------------------- | ------- | --- | --- | --- | ---- | ---- | ---- | ---- | ---- | ---------- |
+| alien-signals          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |          ❌ |
+| @preact/signals-core   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| @reactively/core       |       ❌ |   ⬜ |   ✅ |   ✅ |    ❌ |    ❌ |    ❌ |    ❌ |    ❌ |          ❌ |
+| tansu                  |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| signal-polyfill (TC39) |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| @vue/reactivity        |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| mobx                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| @reatom/core           |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |          ✅ |
+| svelte                 |       ✅ |   ⬜ |   ✅ |   ❌ |    ❌ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| solid-js               |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| @solidjs/signals       |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |          ✅ |
+| S.js                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ❌ |    ❌ |    ❌ |          ✅ |
+| pota                   |       ✅ |   ✅ |   ❌ |   ✅ |    ❌ |    ❌ |    ✅ |    ✅ |    ❌ |          ❌ |
+| @angular/core          |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ❌ |    ❌ |          ✅ |
+| anod                   |       ✅ |   ✅ |   ✅ |   ✅ |    ✅ |    ✅ |    ✅ |    ✅ |    ✅ |          ✅ |
 
 <details>
 <summary>Tests with failures or skips</summary>
@@ -896,6 +896,29 @@ Regression observed in alien-signals 3.2.0 (works in 3.1.2):
 after the inner re-runs once on its own, the outer's link
 to a is dropped and a.write no longer triggers it.
 See https://github.com/stackblitz/alien-signals/issues/115
+
+#### #227 outer responds after one of multiple sibling inners re-runs
+
+```
+ S(a) ─→ E_outer{ E_inner1 ─→ S(b1),  E_inner2 ─→ S(b2) }
+```
+
+Outer creates two sibling inner effects. After only one of them
+re-runs (via its own dep), the outer must still respond to a.
+Same parent-child link integrity property as #226, but with
+sibling inners — could expose bugs where one inner's re-run
+corrupts the other or the parent's link.
+
+#### #228 outer responds after inner re-runs multiple times
+
+```
+ S(a) ─→ E_outer{ E_inner ─→ S(b) }
+ b.write × 3
+```
+
+Inner re-runs multiple times via successive writes to b. After
+the burst, the outer must still respond to a. Verifies the
+parent-child link survives repeated inner re-runs, not just one.
 
 
 </details>

--- a/src/nestedEffects.ts
+++ b/src/nestedEffects.ts
@@ -352,4 +352,86 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
     a.write(1);
     expect(outerRuns).toBe(2);
   },
+
+  /**
+   *  S(a) ─→ E_outer{ E_inner1 ─→ S(b1),  E_inner2 ─→ S(b2) }
+   *
+   * Outer creates two sibling inner effects. After only one of them
+   * re-runs (via its own dep), the outer must still respond to a.
+   * Same parent-child link integrity property as #226, but with
+   * sibling inners — could expose bugs where one inner's re-run
+   * corrupts the other or the parent's link.
+   */
+  "#227 outer responds after one of multiple sibling inners re-runs"(
+    fw: ReactiveFramework
+  ) {
+    const a = fw.signal(0);
+    const b1 = fw.signal(0);
+    const b2 = fw.signal(0);
+    let outerRuns = 0;
+    let inner1Runs = 0;
+    let inner2Runs = 0;
+
+    fw.effect(() => {
+      a.read();
+      outerRuns++;
+      fw.effect(() => {
+        b1.read();
+        inner1Runs++;
+      });
+      fw.effect(() => {
+        b2.read();
+        inner2Runs++;
+      });
+    });
+    expect(outerRuns).toBe(1);
+    expect(inner1Runs).toBe(1);
+    expect(inner2Runs).toBe(1);
+
+    // Only inner1 re-runs
+    b1.write(1);
+    expect(outerRuns).toBe(1);
+    expect(inner1Runs).toBeGreaterThanOrEqual(2);
+
+    // Outer must still respond to its own dep
+    a.write(1);
+    expect(outerRuns).toBe(2);
+  },
+
+  /**
+   *  S(a) ─→ E_outer{ E_inner ─→ S(b) }
+   *  b.write × 3
+   *
+   * Inner re-runs multiple times via successive writes to b. After
+   * the burst, the outer must still respond to a. Verifies the
+   * parent-child link survives repeated inner re-runs, not just one.
+   */
+  "#228 outer responds after inner re-runs multiple times"(
+    fw: ReactiveFramework
+  ) {
+    const a = fw.signal(0);
+    const b = fw.signal(0);
+    let outerRuns = 0;
+    let innerRuns = 0;
+
+    fw.effect(() => {
+      a.read();
+      outerRuns++;
+      fw.effect(() => {
+        b.read();
+        innerRuns++;
+      });
+    });
+    expect(outerRuns).toBe(1);
+    expect(innerRuns).toBe(1);
+
+    b.write(1);
+    b.write(2);
+    b.write(3);
+    expect(outerRuns).toBe(1);
+    expect(innerRuns).toBeGreaterThanOrEqual(2);
+
+    a.write(1);
+    expect(outerRuns).toBe(2);
+  },
 };

--- a/src/nestedEffects.ts
+++ b/src/nestedEffects.ts
@@ -311,4 +311,45 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
 
     expect(observed).toContain(0);
   },
+
+  /**
+   *  S(a) ─→ E_outer{ E_inner ─→ S(b) }
+   *
+   * Outer reads a and creates an inner effect that reads b.
+   * After b changes (which re-runs only the inner), the outer
+   * must still respond to subsequent writes to its own dep a.
+   *
+   * Regression observed in alien-signals 3.2.0 (works in 3.1.2):
+   * after the inner re-runs once on its own, the outer's link
+   * to a is dropped and a.write no longer triggers it.
+   * See https://github.com/stackblitz/alien-signals/issues/115
+   */
+  "#226 outer keeps responding to own deps after inner re-runs"(
+    fw: ReactiveFramework
+  ) {
+    const a = fw.signal(0);
+    const b = fw.signal(0);
+    let outerRuns = 0;
+    let innerRuns = 0;
+
+    fw.effect(() => {
+      a.read();
+      outerRuns++;
+      fw.effect(() => {
+        b.read();
+        innerRuns++;
+      });
+    });
+    expect(outerRuns).toBe(1);
+    expect(innerRuns).toBe(1);
+
+    // Trigger inner via b — outer must NOT re-run (b is not its dep)
+    b.write(1);
+    expect(outerRuns).toBe(1);
+    expect(innerRuns).toBeGreaterThanOrEqual(2);
+
+    // Trigger outer via a — must re-run despite inner having re-run earlier
+    a.write(1);
+    expect(outerRuns).toBe(2);
+  },
 };


### PR DESCRIPTION
## Summary

Adds three Nested Effects tests around a coverage gap that none of the existing tests caught: **parent-child link integrity when an inner effect re-runs alone**.

Existing nested-effect tests only covered single-trigger paths (write outer's dep / write inner's dep / dispose). Nothing tested the interleaved case where the inner re-runs first on its own, then the outer's dep changes — which is exactly where alien-signals 3.2.0 broke compared to 3.1.2.

| Test | Topology | Stresses |
|------|----------|----------|
| `#226 outer keeps responding to own deps after inner re-runs` | `S(a) → outer{ inner → S(b) }` | inner re-runs once, outer's link to `a` |
| `#227 outer responds after one of multiple sibling inners re-runs` | `S(a) → outer{ inner1 → S(b1), inner2 → S(b2) }` | sibling-inner case — one inner's re-run shouldn't corrupt the other or the parent link |
| `#228 outer responds after inner re-runs multiple times` | `S(a) → outer{ inner → S(b) }`, write `b` × 3 | parent link survives repeated inner re-runs, not just one |

## Reveals real bugs

[stackblitz/alien-signals#115](https://github.com/stackblitz/alien-signals/issues/115) — alien-signals 3.2.0 regression where after the inner re-runs on its own, the outer's link to its own dep is dropped. All three new tests reproduce it.

| Framework | `#226` | `#227` | `#228` |
|---|---|---|---|
| alien-signals | ❌ | ❌ | ❌ |
| @reactively/core | ❌ | ❌ | ❌ |
| pota | ❌ | ❌ | ❌ |
| all others | ✅ | ✅ | ✅ |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 2730 passed (15 frameworks × (166 non-behavioral + 16 behavioral))
- [x] README regenerated