### PR TITLE
Add flush-queue consistency test (#247) + scope-throw behavioral probe (#246)

### DIFF
--- a/src/behaviorDifferences.ts
+++ b/src/behaviorDifferences.ts
@@ -459,6 +459,35 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
   },
 
   /**
+   *  run{ E(child ─→ S(source)); throw }
+   *
+   * A scope/root body creates a child effect then throws before
+   * returning. Checks whether the framework disposes child
+   * effects created before the throw or leaves them alive.
+   * Returns "disposes children" or "children survive".
+   */
+  "#246 throwing run body child effect cleanup"(fw: ReactiveFramework) {
+    const source = fw.signal(0);
+    let childRuns = 0;
+
+    try {
+      fw.run(() => {
+        fw.effect(() => {
+          childRuns++;
+          source.read();
+        });
+        throw new Error("scope setup failed");
+      });
+    } catch {}
+
+    childRuns = 0;
+    try {
+      source.write(1);
+    } catch {}
+    return childRuns === 0 ? "disposes children" : "children survive";
+  },
+
+  /**
    *  E_outer{ E_inner1, E_inner2, E_inner3 } → dispose
    *
    * Probes the cleanup order of sibling effects when their owner

--- a/src/errorHandling.ts
+++ b/src/errorHandling.ts
@@ -322,6 +322,52 @@ export const cases: Record<string, (fw: ReactiveFramework) => any> = {
   },
 
   /**
+   *  S(a) ← E(e1)
+   *  S(a) ← E(e2 ⚡ throws when a===1)
+   *  S(a) ← E(e3)
+   *  S(b) ← E(e4)
+   *
+   * e2 throws during propagation of a(1), which may halt the
+   * flush. On a subsequent write to unrelated signal b, only
+   * b-dependent effects must run — a-dependent effects skipped
+   * by the earlier halt must NOT leak into the new flush.
+   */
+  "#247 flush queue consistent after effect throw"(
+    fw: ReactiveFramework
+  ) {
+    const a = fw.signal(0);
+    const b = fw.signal(0);
+    let e3Runs = 0;
+
+    fw.effect(() => {
+      a.read();
+    });
+    try {
+      fw.effect(() => {
+        if (a.read() === 1) throw new Error("e2 error");
+      });
+    } catch {}
+    fw.effect(() => {
+      a.read();
+      e3Runs++;
+    });
+    fw.effect(() => {
+      b.read();
+    });
+
+    e3Runs = 0;
+    try {
+      a.write(1);
+    } catch {}
+    e3Runs = 0;
+
+    try {
+      b.write(1);
+    } catch {}
+    expect(e3Runs).toBe(0);
+  },
+
+  /**
    *  S(a) → C(b) ⚡ throws when a is true
    *
    * Computed alternates between throwing and returning "ok".


### PR DESCRIPTION
## Summary

- **#247** (conformance): Tests that after an effect throws during flush, writing to an unrelated signal does not trigger effects skipped from the halted flush. Ensures flush queue state is properly reset after an error (per [alien-signals#97](https://github.com/stackblitz/alien-signals/issues/97)).
- **#246** (behavioral difference): Records whether each framework disposes child effects when a `run`/scope body throws before returning.

### Results

**#247 flush queue consistent after effect throw** (12/15 pass)

| Framework | Result |
|---|---|
| alien-signals, preact, reactively, tansu, TC39, vue, mobx, reatom, svelte, solid-js, S.js, anod | ✅ |
| @solidjs/signals, pota, @angular/core | ❌ |

**#246 throwing run body child effect cleanup** (behavioral)

| Behavior | Frameworks |
|---|---|
| disposes children | @reactively/core, @reatom/core, pota |
| children survive | alien-signals, preact, tansu, TC39, vue, mobx, svelte, solid-js, @solidjs/signals, S.js, @angular/core, anod |

### Context

[alien-signals#118](https://github.com/stackblitz/alien-signals/issues/118) proposed that throwing effects/scopes should auto-dispose. After discussion, we determined this is a design choice (not a correctness requirement) — the real correctness issue is flush queue corruption ([alien-signals#97](https://github.com/stackblitz/alien-signals/issues/97)). #247 tests the correctness requirement; #246 documents the design choice.